### PR TITLE
Rename Lightspeed GMI to Lightspeed

### DIFF
--- a/companies.md
+++ b/companies.md
@@ -141,14 +141,14 @@ Bellevue, WA 98008
 
 ## L 
 
-**Lightspeed GMI**
+**Lightspeed**
 ```
 600 108th Ave NE
 Suite 202
 Bellevue, WA 98004
 ```
 
-http://www.lightspeedgmi.com/
+http://www.lightspeedresearch.com/
 [@LightspeedGMI](https://twitter.com/LightspeedGMI) 
 
 PHP Tech: Zend Framework, Symfony


### PR DESCRIPTION
Lightspeed GMI renamed itself to Lightspeed in September 2016.  Oddly I can only find a [reference][1] on the sister companies' websites and not on Lightspeed's website.

[1]: http://www.tnsglobal.com/press-release/kantar-unveils-new-corporate-identity-across-its-operating-brands