### PR TITLE
Remove note for recruiter's presence in Seattle

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,6 @@ know of any PHP-based companies with offices in the Seattle area, add them here.
 They're helpful for people who are looking for jobs. So to make things easy, we added a markdown file for recruiters and staffing companies.
 
 * Use the recruiters.md file
-* Need to have a presence in Seattle Area
 * Try to limit to companies within 20 miles.
 
 [Recruiters](recruiters.md)


### PR DESCRIPTION
Many recruiters have jobs for candidates in Seattle but aren't necessarily located in Seattle themselves.  The recruiting process generally does not require the candidate to visit the recruiter's office, so there is no need for all recruiters to be local to the city for which they are recruiting for.  Furthermore, the list currently contains 48 recruiters and only 4 are known to have a Seattle office.